### PR TITLE
reset default link styles

### DIFF
--- a/themes/coop-radio/sass/_navigation.scss
+++ b/themes/coop-radio/sass/_navigation.scss
@@ -77,9 +77,6 @@ a {
     &.focus > a {
     }
   }
-  a {
-    text-decoration: none;
-  }
 
   .current_page_item > a,
   .current-menu-item > a,

--- a/themes/coop-radio/style.css
+++ b/themes/coop-radio/style.css
@@ -570,9 +570,6 @@ a {
 .main-navigation li {
   position: relative; }
 
-.main-navigation a {
-  text-decoration: none; }
-
 .menu-toggle {
   display: block; }
 


### PR DESCRIPTION
- set the text-decoration for a links to none

- some a links that are nested in several classes might still have the underline (ie. look at front-page's "view")